### PR TITLE
Shortcuts: loop playback and run-while-held

### DIFF
--- a/src/CrossMacro.Core/Models/ShortcutTask.cs
+++ b/src/CrossMacro.Core/Models/ShortcutTask.cs
@@ -94,7 +94,62 @@ public class ShortcutTask : INotifyPropertyChanged
     /// Whether the task can be enabled (has both macro file path and hotkey)
     /// </summary>
     public bool CanBeEnabled => !string.IsNullOrEmpty(MacroFilePath) && !string.IsNullOrEmpty(HotkeyString);
-    
+
+    private bool _loopEnabled;
+    public bool LoopEnabled
+    {
+        get => _loopEnabled;
+        set
+        {
+            if (_loopEnabled == value) return;
+            _loopEnabled = value;
+            if (value) { _runWhileHeld = false; OnPropertyChanged(nameof(RunWhileHeld)); }
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsLoopEnabled));
+        }
+    }
+
+    private int _repeatCount = 0;
+    public int RepeatCount
+    {
+        get => _repeatCount;
+        set { _repeatCount = value; OnPropertyChanged(); }
+    }
+
+    private int _repeatDelayMs = 0;
+    public int RepeatDelayMs
+    {
+        get => _repeatDelayMs;
+        set { _repeatDelayMs = value; OnPropertyChanged(); }
+    }
+
+    private bool _runWhileHeld;
+    public bool RunWhileHeld
+    {
+        get => _runWhileHeld;
+        set
+        {
+            if (_runWhileHeld == value) return;
+            _runWhileHeld = value;
+            if (value) { _loopEnabled = false; OnPropertyChanged(nameof(LoopEnabled)); }
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsLoopEnabled));
+        }
+    }
+
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool IsLoopEnabled
+    {
+        get => _loopEnabled || _runWhileHeld;
+        set
+        {
+            if (value == IsLoopEnabled) return;
+            if (value) { _loopEnabled = true; _runWhileHeld = false; OnPropertyChanged(nameof(LoopEnabled)); OnPropertyChanged(nameof(RunWhileHeld)); }
+            else { _loopEnabled = false; _runWhileHeld = false; OnPropertyChanged(nameof(LoopEnabled)); OnPropertyChanged(nameof(RunWhileHeld)); }
+            OnPropertyChanged();
+        }
+    }
+
     /// <summary>
     /// Status message from last execution
     /// </summary>

--- a/src/CrossMacro.Core/Services/IGlobalHotkeyService.cs
+++ b/src/CrossMacro.Core/Services/IGlobalHotkeyService.cs
@@ -44,6 +44,11 @@ public interface IGlobalHotkeyService : IDisposable
     /// </summary>
     event EventHandler<RawHotkeyInputEventArgs>? RawInputReceived;
 
+    /// <summary>
+    /// Event fired when a key is released (same hotkey string as when pressed)
+    /// </summary>
+    event EventHandler<RawHotkeyInputEventArgs>? RawKeyReleased;
+
 
     /// <summary>
     /// Event fired when a critical error occurs (e.g., daemon connection failure)

--- a/src/CrossMacro.UI/CrossMacro.UI.csproj
+++ b/src/CrossMacro.UI/CrossMacro.UI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
@@ -6,6 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <ApplicationIcon>Assets\mouse-icon.ico</ApplicationIcon>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
+    <AvaloniaStatsTaskEnabled>false</AvaloniaStatsTaskEnabled>
     <InvariantGlobalization>true</InvariantGlobalization>
     <Version>0.9.0</Version>
     <Description>Cross-platform mouse and keyboard macro automation tool with text expansion support.</Description>

--- a/src/CrossMacro.UI/ViewModels/DesignMainWindowViewModel.cs
+++ b/src/CrossMacro.UI/ViewModels/DesignMainWindowViewModel.cs
@@ -250,6 +250,7 @@ public class DesignMainWindowViewModel : MainWindowViewModel
         public event EventHandler? TogglePlaybackRequested;
         public event EventHandler? TogglePauseRequested;
         public event EventHandler<RawHotkeyInputEventArgs>? RawInputReceived;
+        public event EventHandler<RawHotkeyInputEventArgs>? RawKeyReleased;
         public event EventHandler<string>? ErrorOccurred;
 #pragma warning restore CS0067
         public int RecordingHotkeyCode => 0;

--- a/src/CrossMacro.UI/Views/Tabs/ShortcutTabView.axaml
+++ b/src/CrossMacro.UI/Views/Tabs/ShortcutTabView.axaml
@@ -182,6 +182,36 @@
                                IsSnapToTickEnabled="True"/>
                     </StackPanel>
                     
+                    <!-- Loop Playback (same pattern as Playback tab) -->
+                    <StackPanel Spacing="12">
+                        <CheckBox Content="Loop Playback"
+                                  IsChecked="{Binding SelectedTask.IsLoopEnabled, Mode=TwoWay}"/>
+                        <StackPanel Spacing="8" IsVisible="{Binding SelectedTask.IsLoopEnabled, FallbackValue=False}">
+                            <RadioButton GroupName="LoopTrigger"
+                                         Content="Press to start/stop"
+                                         IsChecked="{Binding SelectedTask.LoopEnabled, Mode=TwoWay}"
+                                         ToolTip.Tip="Press shortcut to start looping; press again to stop."/>
+                            <RadioButton GroupName="LoopTrigger"
+                                         Content="Run when held"
+                                         IsChecked="{Binding SelectedTask.RunWhileHeld, Mode=TwoWay}"
+                                         ToolTip.Tip="Hold shortcut to run; release to stop. Keyboard trigger only."/>
+                            <Grid ColumnDefinitions="*,*">
+                                <StackPanel Grid.Column="0" Spacing="4" Margin="0,0,8,0">
+                                    <TextBlock Classes="label" Text="Loop Count"/>
+                                    <NumericUpDown Value="{Binding SelectedTask.RepeatCount, Mode=TwoWay}" Minimum="0" Maximum="10000" FormatString="0"/>
+                                </StackPanel>
+                                <StackPanel Grid.Column="1" Spacing="4" Margin="8,0,0,0">
+                                    <TextBlock Classes="label" Text="Loop Delay (ms)"/>
+                                    <NumericUpDown Value="{Binding SelectedTask.RepeatDelayMs, Mode=TwoWay}" Minimum="0" Maximum="2147483647" Increment="100" FormatString="0"/>
+                                </StackPanel>
+                            </Grid>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Spacing="4" Margin="0,4,0,0">
+                                <TextBlock Text="💡" FontSize="12" FontFamily="{StaticResource EmojiFont}" Opacity="0.7"/>
+                                <TextBlock Text="Tip: Loop Count 0 means infinite loop" Classes="label" FontSize="12" Opacity="0.7"/>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                    
                     <!-- Macro File -->
                     <StackPanel Spacing="4">
                         <TextBlock Text="Macro File" FontSize="12" Opacity="0.7"/>


### PR DESCRIPTION
- Add Loop Playback to shortcut tasks: checkbox (like Playback tab) to enable looping with Loop Count and Loop Delay (ms).
- Two mutually exclusive modes: Press to start/stop (toggle) or Run when held (keyboard only; release to stop).
- ShortcutService: pass loop options into PlaybackOptions; subscribe to RawKeyReleased for run-while-held stop on key release.
- IGlobalHotkeyService/GlobalHotkeyService: add RawKeyReleased event; fire on key release with hotkey string for hold-to-stop.
- ShortcutTask: LoopEnabled, RepeatCount, RepeatDelayMs, RunWhileHeld; IsLoopEnabled (UI-only) for Loop Playback checkbox; mutual exclusion between LoopEnabled and RunWhileHeld.
- Shortcut tab UI: Loop Playback checkbox, radios, Loop Count/Delay, centered tip (Loop Count 0 = infinite).
- Disable Avalonia build telemetry (AvaloniaStatsTaskEnabled=false) while we're at it.