### PR TITLE
fix(ui): prevent second instance bypassing single-instance guard via Local mutex fallback

### DIFF
--- a/src/CrossMacro.UI/SingleInstanceGuard.cs
+++ b/src/CrossMacro.UI/SingleInstanceGuard.cs
@@ -21,19 +21,22 @@ internal sealed class SingleInstanceGuard : IDisposable
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(name);
 
-        var guard = TryAcquireCore(name);
+        var (guard, unauthorized) = TryAcquireCore(name);
         if (guard != null)
         {
             return guard;
         }
 
-        // Regular desktop users may not have permission to create a Global mutex on Windows.
-        // Fall back to a session-local lock so single-instance behavior still works.
-        if (OperatingSystem.IsWindows() &&
+        // Only fall back to a session-local lock when the Global mutex could not be
+        // created/accessed due to insufficient permissions.  If the Global mutex exists
+        // and is already held by another instance, we must NOT fall back — doing so would
+        // acquire a different (Local) mutex and allow a second instance to start.
+        if (unauthorized &&
+            OperatingSystem.IsWindows() &&
             name.StartsWith(GlobalPrefix, StringComparison.Ordinal))
         {
             var localName = LocalPrefix + name[GlobalPrefix.Length..];
-            guard = TryAcquireCore(localName);
+            (guard, _) = TryAcquireCore(localName);
 
             if (guard != null)
             {
@@ -44,7 +47,7 @@ internal sealed class SingleInstanceGuard : IDisposable
         return null;
     }
 
-    private static SingleInstanceGuard? TryAcquireCore(string name)
+    private static (SingleInstanceGuard? Guard, bool Unauthorized) TryAcquireCore(string name)
     {
         Mutex? mutex = null;
         bool hasHandle;
@@ -64,21 +67,21 @@ internal sealed class SingleInstanceGuard : IDisposable
             catch (UnauthorizedAccessException)
             {
                 mutex.Dispose();
-                return null;
+                return (null, true);
             }
 
             if (!hasHandle)
             {
                 mutex.Dispose();
-                return null;
+                return (null, false);
             }
 
-            return new SingleInstanceGuard(mutex, hasHandle: true);
+            return (new SingleInstanceGuard(mutex, hasHandle: true), false);
         }
         catch (UnauthorizedAccessException)
         {
             mutex?.Dispose();
-            return null;
+            return (null, true);
         }
         catch
         {


### PR DESCRIPTION
## Summary

`SingleInstanceGuard.TryAcquireCore` returned `null` for both "mutex already held by another instance" and "unauthorized access" cases. When the first instance held a `Global\` mutex, a second instance would fail on `Global\`, then fall back to a `Local\` mutex (a different named mutex) and succeed — allowing two instances to run simultaneously.

`TryAcquireCore` now returns a `(SingleInstanceGuard? Guard, bool Unauthorized)` tuple so the caller can distinguish permission errors from an already-held lock. The `Local\` fallback is only triggered on `UnauthorizedAccessException`, not when the mutex is already held.

## Test plan

- [x] Existing `SingleInstanceGuardTests` pass on all platforms
- [x] Manual test: launched first instance, second instance exits immediately with `"Could not acquire single-instance lock"` (exit code 5)